### PR TITLE
Deserialize empty tuple as unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- Compatibility with Quint v0.19.0
+- Deserialize empty tuple as unit ([#15](https://github.com/informalsystems/itf-rs/pull/15))
+
 ## v0.2.2
 
 *December 7th, 2023*

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -73,6 +73,7 @@ impl<'de> Deserializer<'de> for Value {
             Value::String(v) => visitor.visit_string(v),
             Value::BigInt(v) => visit_bigint(v, visitor),
             Value::List(v) => visit_list(v, visitor),
+            Value::Tuple(v) if v.is_empty() => visitor.visit_unit(),
             Value::Tuple(v) => visit_tuple(v, visitor),
             Value::Set(v) => visit_set(v, visitor),
             Value::Record(v) => visit_record(v, visitor),

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -215,6 +215,7 @@ fn test_failed_bare_bigint_to_int() {
 fn test_complete() {
     use std::collections::{BTreeSet, HashMap, HashSet};
 
+    #[allow(dead_code)]
     #[derive(Deserialize, Debug)]
     #[serde(untagged)]
     enum RecordEnum {
@@ -250,4 +251,32 @@ fn test_complete() {
     });
 
     let _: Complete = itf::from_value(itf).unwrap();
+}
+
+#[test]
+fn test_enum_unit_variant() {
+    #[derive(Debug, PartialEq, serde::Deserialize)]
+    #[serde(tag = "tag", content = "value")]
+    pub enum VKOutput {
+        #[serde(rename = "NoVKOutput")]
+        NoOutput,
+    }
+
+    let obj = serde_json::json!({
+        "lastEmitted": {
+            "tag": "NoVKOutput",
+            "value": {
+                "#tup": []
+            }
+        }
+    });
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Test {
+        last_emitted: VKOutput,
+    }
+
+    let itf_value = itf::from_value::<Test>(obj).unwrap();
+    assert_eq!(itf_value.last_emitted, VKOutput::NoOutput);
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -253,9 +253,10 @@ fn test_complete() {
     let _: Complete = itf::from_value(itf).unwrap();
 }
 
+// Test extracted from the malachite MBT tests
 #[test]
 fn test_enum_unit_variant() {
-    #[derive(Debug, PartialEq, serde::Deserialize)]
+    #[derive(Debug, PartialEq, Deserialize)]
     #[serde(tag = "tag", content = "value")]
     pub enum VKOutput {
         #[serde(rename = "NoVKOutput")]


### PR DESCRIPTION
Since Quint v0.19, the unit type is encoded as an empty tuple.